### PR TITLE
fixing provider to use pagination on ds fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.16
+
+FIXES: 
+* fixed issue when atlassian group has more than 200 members - added pagination
+
+
 ## 0.1.0 (Unreleased)
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,6 @@
-# Terraform Provider Scaffolding (Terraform Plugin Framework)
+# Terraform Provider for Atlassian Confluence (built on Terraform Plugin Framework)
 
-_This template repository is built on the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework). The template repository built on the [Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) can be found at [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding). See [Which SDK Should I Use?](https://www.terraform.io/docs/plugin/which-sdk.html) in the Terraform documentation for additional information._
-
-This repository is a *template* for a [Terraform](https://www.terraform.io) provider. It is intended as a starting point for creating Terraform providers, containing:
-
-- A resource and a data source (`internal/provider/`),
-- Examples (`examples/`) and generated documentation (`docs/`),
-- Miscellaneous meta files.
-
-These files contain boilerplate code that you will need to edit to create your own Terraform provider. Tutorials for creating Terraform providers can be found on the [HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/providers-plugin-framework) platform. _Terraform Plugin Framework specific guides are titled accordingly._
-
-Please see the [GitHub template repository documentation](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) for how to create a new repository from this template on GitHub.
-
-Once you've written your provider, you'll want to [publish it on the Terraform Registry](https://www.terraform.io/docs/registry/providers/publishing.html) so that others can use it.
-
+_This terraform provider repository is built on the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework).
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0

--- a/internal/provider/group_membership_data_source_test.go
+++ b/internal/provider/group_membership_data_source_test.go
@@ -194,9 +194,9 @@ var (
       "_links": {}
     }
   ],
-  "start": 2154,
-  "limit": 2154,
-  "size": 2154,
+  "start": 0,
+  "limit": 200,
+  "size": 1,
   "totalSize": 150,
   "_links": {}
 }

--- a/internal/provider/space_resource_test.go
+++ b/internal/provider/space_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func generateTestExceptionItem() transferobjects.Space {
+func generateTestSpaceObject() transferobjects.Space {
 	base := transferobjects.Space{
 		Id:   123,
 		Name: "asdasd",
@@ -48,8 +48,8 @@ func TestSpaceResourceResource(t *testing.T) {
 	}
 
 	svr.SetSplice("/rest/api/space", func(a string, b []byte) (string, map[string]interface{}) {
-		id := generateTestExceptionItem().Id
-		jsonStr, _ := json.Marshal(generateTestExceptionItem())
+		id := generateTestSpaceObject().Id
+		jsonStr, _ := json.Marshal(generateTestSpaceObject())
 		var obj map[string]interface{}
 		_ = json.Unmarshal(jsonStr, &obj)
 		return id.String(), obj
@@ -64,10 +64,10 @@ func TestSpaceResourceResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccExceptionItemResourceConfig(generateTestExceptionItem(), "test"),
+				Config: testAccExceptionItemResourceConfig(generateTestSpaceObject(), "test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					fakeserver.TestAccCheckRestapiObjectExists("confluence_space.test", "id", client),
-					resource.TestCheckResourceAttr("confluence_space.test", "key", generateTestExceptionItem().Key),
+					resource.TestCheckResourceAttr("confluence_space.test", "key", generateTestSpaceObject().Key),
 				),
 			},
 			// ImportState testing
@@ -83,9 +83,9 @@ func TestSpaceResourceResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccExceptionItemResourceConfig(generateTestExceptionItem(), "test"),
+				Config: testAccExceptionItemResourceConfig(generateTestSpaceObject(), "test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("confluence_space.test", "key", generateTestExceptionItem().Key),
+					resource.TestCheckResourceAttr("confluence_space.test", "key", generateTestSpaceObject().Key),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
Addresses issue described in https://github.com/fabiogermann/terraform-provider-confluence/issues/1 
Using pagination to fetch all users from the api instead of only the first 200